### PR TITLE
Include cstdint

### DIFF
--- a/DataContainerGenerator/parsing.hpp
+++ b/DataContainerGenerator/parsing.hpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstring>
 #include <limits>
+#include <cstdint>
 
 struct char_range {
 	char const* start;

--- a/DataContainerGenerator/source_builder.hpp
+++ b/DataContainerGenerator/source_builder.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <functional>
 #include <utility>
+#include <cstdint>
 
 class raw_lines {
 public:


### PR DESCRIPTION
Why doesn't every compiler complain about this?
I'm using clang, and the lack of this import stops it from compiling.