### PR TITLE
Change if statement order to ensure SSE 4.2 is picked over SSE3 if applicable

### DIFF
--- a/CommonIncludes/ve.hpp
+++ b/CommonIncludes/ve.hpp
@@ -42,10 +42,10 @@ namespace concurrency = oneapi::tbb;
 #ifdef __AVX__
 #include "ve_avx.hpp"
 #else
-#ifdef __SSE3__ //MSVC won't define it by default
-#include "ve_sse3.hpp"
-#else
+#ifdef __SSE4_2__ 
 #include "ve_sse.hpp"
+#else // Worst case, fallback to SSE3
+#include "ve_sse3.hpp"
 #endif
 #endif
 #endif


### PR DESCRIPTION
Change the order so it tests SSE4.2 before fallbacking to SSE3. 
MSVC won't define the __SSE3__ macro so the previous version works fine with it, but Clang does define it and can end up using the SSE3 version if AVX is not available, while SSE4.2 is.